### PR TITLE
Fix Python 3.10 compatibility issues

### DIFF
--- a/etl/extract/brapi.py
+++ b/etl/extract/brapi.py
@@ -302,6 +302,6 @@ def main(config):
         threads.append(thread)
 
     for thread in threads:
-        while thread.isAlive():
+        while thread.is_alive():
             thread.join(500)
 

--- a/etl/transform/elasticsearch.py
+++ b/etl/transform/elasticsearch.py
@@ -318,5 +318,5 @@ def main(config):
         threads.append(thread)
 
     for thread in threads:
-        while thread.isAlive():
+        while thread.is_alive():
             thread.join(500)

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -150,7 +150,7 @@ class TestUpdateIn(unittest.TestCase):
         value = 0
         expected = {}
         actual = update_in(data, path, value)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_one_level(self):
         data = {}
@@ -158,7 +158,7 @@ class TestUpdateIn(unittest.TestCase):
         value = 0
         expected = {'a': 0}
         actual = update_in(data, path, value)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_multi_levels(self):
         data = {}
@@ -166,7 +166,7 @@ class TestUpdateIn(unittest.TestCase):
         value = 'foo'
         expected = {'a': {'b': {'c': 'foo'}}}
         actual = update_in(data, path, value)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_existing_levels(self):
         data = {'a': {'b': {'c': 'bar'}}}
@@ -174,7 +174,7 @@ class TestUpdateIn(unittest.TestCase):
         value = 'foo'
         expected = {'a': {'b': {'c': 'foo'}}}
         actual = update_in(data, path, value)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_array_levels(self):
         data = {
@@ -198,4 +198,4 @@ class TestUpdateIn(unittest.TestCase):
             ]
         }
         actual = update_in(data, path, value)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
Fixes #50 . Deprecated unittest aliases have been removed in Python 3.11. This changes assertEquals to assertEqual to fix that.